### PR TITLE
Ignore small trades when updating the ExchangedRate price metric

### DIFF
--- a/monitor/stability.go
+++ b/monitor/stability.go
@@ -133,8 +133,8 @@ func (p stabilityProcessor) HandleLog(eventLog *types.Log) {
 			event := eventRaw.(*contracts.ExchangeExchanged)
 			logEventLog(logger, "eventName", eventName, "exchanger", event.Exchanger, "soldGold", event.SoldGold, "sellAmount", event.SellAmount, "buyAmount", event.BuyAmount)
 
-			minSellAmountInWei := big.NewInt(1e6)
 			// Prevent updating the ExchangedRate metric for small trades that do not provide enough precision when calculating the effective price
+			minSellAmountInWei := big.NewInt(1e6)
 			if event.SellAmount.Cmp(minSellAmountInWei) < 0 {
 			    return
 			}

--- a/monitor/stability.go
+++ b/monitor/stability.go
@@ -133,6 +133,12 @@ func (p stabilityProcessor) HandleLog(eventLog *types.Log) {
 			event := eventRaw.(*contracts.ExchangeExchanged)
 			logEventLog(logger, "eventName", eventName, "exchanger", event.Exchanger, "soldGold", event.SoldGold, "sellAmount", event.SellAmount, "buyAmount", event.BuyAmount)
 
+			minSellAmountInWei := big.NewInt(1e6)
+			// Prevent updating the ExchangedRate metric for small trades that do not provide enough precision when calculating the effective price
+			if event.SellAmount.Cmp(minSellAmountInWei) < 0 {
+			    return
+			}
+
 			num := event.SellAmount
 			dem := event.BuyAmount
 


### PR DESCRIPTION
This prevents us from updating the value of the ExchangedRate metrics with imprecise values that create aggressive price spikes in the monitoring dashboards.

For example with the current CELO/cUSD price of ~2.06 a sell trade of 4 cUSD (in WEI) ends up updating the metric with an effective price of 4.0 (4 cUSD -> 1 CELO).

I chose 1e6 as the threshold for considering a trade to be too small, which gives us at least 6 digits of precision when calculating the effective price.