### PR TITLE
Add back some mistakenly removed exchange metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/celo-org/celo-blockchain v0.0.0-20210310231833-1918831df39d
-	github.com/celo-org/kliento v0.2.1-0.20210315163928-407560c532d2
+	github.com/celo-org/kliento v0.2.1-0.20210323161435-2992b2ce0cc5
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/celo-org/celo-blockchain v0.0.0-20210310231833-1918831df39d
-	github.com/celo-org/kliento v0.2.1-0.20210323161435-2992b2ce0cc5
+	github.com/celo-org/kliento v0.2.1-0.20210406112616-a86363193f81
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -79,6 +79,8 @@ github.com/celo-org/kliento v0.2.1-0.20210315163928-407560c532d2 h1:WY2yqG6Bb/Np
 github.com/celo-org/kliento v0.2.1-0.20210315163928-407560c532d2/go.mod h1:M/HTJUVMSAdqynAJHQD3mwsE8lAl6vT/EXED6jqEKSo=
 github.com/celo-org/kliento v0.2.1-0.20210323161435-2992b2ce0cc5 h1:V1TIj9rW/vI0LPeqKsa6RQNjf1BIlNVYM8CRBq5gJzo=
 github.com/celo-org/kliento v0.2.1-0.20210323161435-2992b2ce0cc5/go.mod h1:M/HTJUVMSAdqynAJHQD3mwsE8lAl6vT/EXED6jqEKSo=
+github.com/celo-org/kliento v0.2.1-0.20210406112616-a86363193f81 h1:UbtKXrYZUJVCEuanyjfW0czk7zvRyTgvQj0qqjyYxeg=
+github.com/celo-org/kliento v0.2.1-0.20210406112616-a86363193f81/go.mod h1:M/HTJUVMSAdqynAJHQD3mwsE8lAl6vT/EXED6jqEKSo=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/celo-org/kliento v0.2.1-0.20210312165111-9c3cc897c7cc h1:2Al4cIRG635F
 github.com/celo-org/kliento v0.2.1-0.20210312165111-9c3cc897c7cc/go.mod h1:M/HTJUVMSAdqynAJHQD3mwsE8lAl6vT/EXED6jqEKSo=
 github.com/celo-org/kliento v0.2.1-0.20210315163928-407560c532d2 h1:WY2yqG6Bb/Npql+xxvm0aUq6ljO/uj+SoRbLQkfP/uI=
 github.com/celo-org/kliento v0.2.1-0.20210315163928-407560c532d2/go.mod h1:M/HTJUVMSAdqynAJHQD3mwsE8lAl6vT/EXED6jqEKSo=
+github.com/celo-org/kliento v0.2.1-0.20210323161435-2992b2ce0cc5 h1:V1TIj9rW/vI0LPeqKsa6RQNjf1BIlNVYM8CRBq5gJzo=
+github.com/celo-org/kliento v0.2.1-0.20210323161435-2992b2ce0cc5/go.mod h1:M/HTJUVMSAdqynAJHQD3mwsE8lAl6vT/EXED6jqEKSo=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -43,11 +43,11 @@ var (
 	}, []string{"stable_token"})
 	ExchangeCeloExchangedRate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "exchange_celo_exchanged_rate",
-		Help: "The implied Stable/CELO rate by exchanges with Exchange.sol",
+		Help: "The implied Stable/CELO rate by exchanges",
 	}, []string{"stable_token"})
 	ExchangeBucketRatio = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "exchange_bucket_ratio",
-		Help: "The most recent ratio during BucketsExchanged",
+		Help: "The most recent ratio during BucketsUpdated",
 	}, []string{"stable_token"})
 	ExchangeImpliedStableRate = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "exchange_implied_stable_rate",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -19,7 +19,7 @@ var (
 	})
 
 	LastBlockProcessed = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "eksportisto_last_block_processed",
+		Name: "last_block_processed",
 		Help: "Last Block Processed by eksportisto",
 	})
 
@@ -77,25 +77,27 @@ var (
 )
 
 func init() {
-	// Register the summary and the histogram with Prometheus's default registry.
-	prometheus.MustRegister(BlockGasUsed)
-	prometheus.MustRegister(CeloTokenSupply)
-	prometheus.MustRegister(GasPrice)
-	prometheus.MustRegister(VotingGoldFraction)
-	prometheus.MustRegister(LastBlockProcessed)
+	registerer := prometheus.WrapRegistererWithPrefix("eksportisto_", prometheus.DefaultRegisterer)
+	// Register application metrics with the eksportisto_ prefix
+	registerer.MustRegister(BlockGasUsed)
+	registerer.MustRegister(CeloTokenSupply)
+	registerer.MustRegister(GasPrice)
+	registerer.MustRegister(VotingGoldFraction)
+	registerer.MustRegister(LastBlockProcessed)
 
-	prometheus.MustRegister(ExchangeCeloBucketSize)
-	prometheus.MustRegister(ExchangeStableBucketSize)
-	prometheus.MustRegister(ExchangeCeloBucketRatio)
-	prometheus.MustRegister(ExchangeCeloExchangedRate)
-	prometheus.MustRegister(ExchangeBucketRatio)
-	prometheus.MustRegister(ExchangeImpliedStableRate)
+	registerer.MustRegister(ExchangeCeloBucketSize)
+	registerer.MustRegister(ExchangeStableBucketSize)
+	registerer.MustRegister(ExchangeCeloBucketRatio)
+	registerer.MustRegister(ExchangeCeloExchangedRate)
+	registerer.MustRegister(ExchangeBucketRatio)
+	registerer.MustRegister(ExchangeImpliedStableRate)
 
-	prometheus.MustRegister(SortedOraclesIsOldestReportExpired)
-	prometheus.MustRegister(SortedOraclesNumRates)
-	prometheus.MustRegister(SortedOraclesMedianRate)
-	prometheus.MustRegister(SortedOraclesRateMaxDeviation)
-	prometheus.MustRegister(SortedOraclesMedianTimestamp)
-	// Add Go module build info.
+	registerer.MustRegister(SortedOraclesIsOldestReportExpired)
+	registerer.MustRegister(SortedOraclesNumRates)
+	registerer.MustRegister(SortedOraclesMedianRate)
+	registerer.MustRegister(SortedOraclesRateMaxDeviation)
+	registerer.MustRegister(SortedOraclesMedianTimestamp)
+
+	// Add Go module build info with the default registry
 	prometheus.MustRegister(prometheus.NewBuildInfoCollector())
 }

--- a/monitor/exchange.go
+++ b/monitor/exchange.go
@@ -138,7 +138,7 @@ func (p exchangeProcessor) HandleEvent(parsedLog *registry.RegistryParsedLog) {
 
 	switch parsedLog.Event {
 	case "Exchanged":
-		event := parsedLog.Log.(contracts.ExchangeExchanged)
+		event := parsedLog.Log.(*contracts.ExchangeExchanged)
 
 		// Prevent updating the ExchangedRate metric for small trades that do not provide enough precision when calculating the effective price
 		minSellAmountInWei := big.NewInt(1e6)
@@ -158,7 +158,7 @@ func (p exchangeProcessor) HandleEvent(parsedLog *registry.RegistryParsedLog) {
 		celoPriceF, _ := celoPrice.Float64()
 		p.exchangeCeloExchangedRateGauge.Set(celoPriceF)
 	case "BucketsUpdated":
-		event := parsedLog.Log.(contracts.ExchangeBucketsUpdated)
+		event := parsedLog.Log.(*contracts.ExchangeBucketsUpdated)
 
 		bucketRatio := utils.DivideBigInts(event.StableBucket, event.GoldBucket)
 		bucketRatioF, _ := bucketRatio.Float64()

--- a/monitor/exchange.go
+++ b/monitor/exchange.go
@@ -137,12 +137,14 @@ func (p exchangeProcessor) HandleEvent(parsedLog *registry.RegistryParsedLog) {
 			return
 		}
 
-		num := event.SellAmount
-		dem := event.BuyAmount
+		var num, dem *big.Int
 
 		if event.SoldGold {
 			num = event.BuyAmount
 			dem = event.SellAmount
+		} else {
+			num = event.SellAmount
+			dem = event.BuyAmount
 		}
 
 		celoPrice := utils.DivideBigInts(num, dem)

--- a/monitor/exchange.go
+++ b/monitor/exchange.go
@@ -127,15 +127,6 @@ func (p exchangeProcessor) ObserveMetric(opts *bind.CallOpts) error {
 }
 
 func (p exchangeProcessor) HandleEvent(parsedLog *registry.RegistryParsedLog) {
-	// eventName, eventRaw, ok, err := p.exchange.TryParseLog(*eventLog)
-	// if err != nil {
-	// 	p.logger.Warn("Ignoring event: Error parsing exchange event", "err", err, "eventId", eventLog.Topics[0].Hex())
-	// 	return
-	// }
-	// if !ok {
-	// 	return
-	// }
-
 	switch parsedLog.Event {
 	case "Exchanged":
 		event := parsedLog.Log.(*contracts.ExchangeExchanged)

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -187,15 +187,15 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 			if err != nil {
 				eventLogger.Error("log parsing failed", "err", err)
 			} else if parsed != nil {
+				// If the contract with the event has an event handler, call it with the parsed event
+				if handler, ok := eventHandlers[registry.ContractID(parsed.Contract)]; ok {
+					handler.HandleEvent(parsed)
+				}
 				logSlice, err := helpers.EventToSlice(parsed.Log)
 				if err != nil {
 					eventLogger.Error("event slice encoding failed", "contract", parsed.Contract, "event", parsed.Event, "err", err)
 				} else {
 					logEventLog(eventLogger, append([]interface{}{"contract", parsed.Contract, "event", parsed.Event}, logSlice...)...)
-					// If the contract with the event has an event handler, call it with the parsed event
-					if handler, ok := eventHandlers[registry.ContractID(parsed.Contract)]; ok {
-						handler.HandleEvent(parsed)
-					}
 				}
 			} else {
 				eventLogger.Warn("log source unknown, logging raw event")

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -299,24 +299,25 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 				return err
 			}
 		}
-		// Create an processor for each stable token's exchange
+		// Create a processor for each stable token's exchange
 		exchangeProcessors := make(map[celotokens.CeloToken]ContractProcessor)
 		for stableToken, exchangeContract := range exchangeContracts {
-			// If a token's contract has not been registered with the Registry
+			// If the exchange contract has not been registered with the Registry
 			// yet, the contract will be nil. Ignore this.
 			if exchangeContract == nil {
 				continue
-			}
-			exchangeRegistryID, err := celotokens.GetExchangeRegistryID(stableToken)
-			if err != nil {
-				return err
 			}
 			exchangeProcessor, err := NewExchangeProcessor(ctx, logger, stableToken, exchangeRegistryID, exchangeContract, reserve)
 			if err != nil {
 				return err
 			}
 			exchangeProcessors[stableToken] = exchangeProcessor
+
 			// We want to process exchange events, so we add exchangeProcessor as an event handler
+			exchangeRegistryID, err := celotokens.GetExchangeRegistryID(stableToken)
+			if err != nil {
+				return err
+			}
 			eventHandlers[exchangeRegistryID] = exchangeProcessor
 		}
 

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -307,6 +307,10 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 			if exchangeContract == nil {
 				continue
 			}
+			exchangeRegistryID, err := celotokens.GetExchangeRegistryID(stableToken)
+			if err != nil {
+				return err
+			}
 			exchangeProcessor, err := NewExchangeProcessor(ctx, logger, stableToken, exchangeRegistryID, exchangeContract, reserve)
 			if err != nil {
 				return err
@@ -314,10 +318,6 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 			exchangeProcessors[stableToken] = exchangeProcessor
 
 			// We want to process exchange events, so we add exchangeProcessor as an event handler
-			exchangeRegistryID, err := celotokens.GetExchangeRegistryID(stableToken)
-			if err != nil {
-				return err
-			}
 			eventHandlers[exchangeRegistryID] = exchangeProcessor
 		}
 

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -316,6 +316,7 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 				return err
 			}
 			exchangeProcessors[stableToken] = exchangeProcessor
+			// We want to process exchange events, so we add exchangeProcessor as an event handler
 			eventHandlers[exchangeRegistryID] = exchangeProcessor
 		}
 

--- a/monitor/sortedOracles.go
+++ b/monitor/sortedOracles.go
@@ -26,10 +26,8 @@ type sortedOraclesProcessor struct {
 	ctx    context.Context
 	logger log.Logger
 
-	// exchanges     map[celotokens.CeloToken]*contracts.Exchange
 	sortedOracles    *contracts.SortedOracles
 	stableTokenInfos map[celotokens.CeloToken]stableTokenInfo
-	// stableTokenAddresses map[celotokens.CeloToken]common.Address
 }
 
 func NewSortedOraclesProcessor(ctx context.Context, logger log.Logger, sortedOracles *contracts.SortedOracles, exchanges map[celotokens.CeloToken]*contracts.Exchange, stableTokenAddresses map[celotokens.CeloToken]common.Address) (*sortedOraclesProcessor, error) {

--- a/monitor/sortedOracles.go
+++ b/monitor/sortedOracles.go
@@ -17,17 +17,17 @@ import (
 )
 
 type stableTokenInfo struct {
-	address  common.Address
-	exchange *contracts.Exchange
+	address     common.Address
+	exchange    *contracts.Exchange
 	stableToken celotokens.CeloToken
 }
 
 type sortedOraclesProcessor struct {
-	ctx           context.Context
-	logger        log.Logger
+	ctx    context.Context
+	logger log.Logger
 
 	// exchanges     map[celotokens.CeloToken]*contracts.Exchange
-	sortedOracles *contracts.SortedOracles
+	sortedOracles    *contracts.SortedOracles
 	stableTokenInfos map[celotokens.CeloToken]stableTokenInfo
 	// stableTokenAddresses map[celotokens.CeloToken]common.Address
 }
@@ -40,8 +40,8 @@ func NewSortedOraclesProcessor(ctx context.Context, logger log.Logger, sortedOra
 			return nil, fmt.Errorf("No exchange provided for stable token %w", stableToken)
 		}
 		stableTokenInfos[stableToken] = stableTokenInfo{
-			address: stableTokenAddress,
-			exchange: exchange,
+			address:     stableTokenAddress,
+			exchange:    exchange,
 			stableToken: stableToken,
 		}
 	}

--- a/monitor/sortedOracles.go
+++ b/monitor/sortedOracles.go
@@ -34,6 +34,7 @@ func NewSortedOraclesProcessor(ctx context.Context, logger log.Logger, sortedOra
 	stableTokenInfos := make(map[celotokens.CeloToken]stableTokenInfo)
 	for stableToken, stableTokenAddress := range stableTokenAddresses {
 		exchange, ok := exchanges[stableToken]
+		// This should never happen, but let's be safe
 		if !ok || exchange == nil {
 			return nil, fmt.Errorf("No exchange provided for stable token %w", stableToken)
 		}

--- a/monitor/types.go
+++ b/monitor/types.go
@@ -2,9 +2,15 @@ package monitor
 
 import (
 	"github.com/celo-org/celo-blockchain/accounts/abi/bind"
+
+	"github.com/celo-org/kliento/registry"
 )
 
 type ContractProcessor interface {
 	ObserveState(opts *bind.CallOpts) error
 	ObserveMetric(opts *bind.CallOpts) error
+}
+
+type EventHandler interface {
+	HandleEvent(parsedLog *registry.RegistryParsedLog)
 }


### PR DESCRIPTION
* Adds back the code to set `ExchangeBucketRatio` and `ExchangeCeloExchangedRate` when exchange events or bucket updates occur. I did this by creating "event handlers", which for now just consists of each exchange processor. This required me moving the looping over all txs in the block to after the creation of all the processors.
* Fixed some logic in sortedOracles.go -- previously, the cUSD exchange was being used when calculating the implied cEUR/USD rate, now that's fixed
* Added a prefix of `eksportisto_` to all the application metrics-- this will make it easier to identify the metrics are coming from eksportisto

Depends on https://github.com/celo-org/kliento/pull/14