### PR TITLE
Fix "memory leak" that was causing the eksportisto performance issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+eksportisto
+.vscode

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -23,6 +23,12 @@ var (
 		Help: "Last Block Processed by eksportisto",
 	})
 
+	ProcessBlockDuration = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "process_block_duration",
+		Help:    "Time it takes to process a block",
+		Buckets: prometheus.LinearBuckets(0, 0.2, 20),
+	})
+
 	VotingGoldFraction = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "epochrewards_votinggoldfraction",
 		Help: "Voting Gold Fraction",
@@ -84,6 +90,7 @@ func init() {
 	registerer.MustRegister(GasPrice)
 	registerer.MustRegister(VotingGoldFraction)
 	registerer.MustRegister(LastBlockProcessed)
+	registerer.MustRegister(ProcessBlockDuration)
 
 	registerer.MustRegister(ExchangeCeloBucketSize)
 	registerer.MustRegister(ExchangeStableBucketSize)

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -140,6 +140,14 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 
 	celoTokens := celotokens.New(r)
 
+	supported, err := cc.Rpc.SupportedModules()
+	if err != nil {
+		return err
+	}
+	_, debugEnabled := supported["debug"]
+
+	sensitiveAccounts := getSensitiveAccounts(cfg.SensitiveAccountsFilePath)
+
 	var h *types.Header
 	for {
 		select {

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -128,7 +128,7 @@ func Start(ctx context.Context, cfg *Config) error {
 	return g.Wait()
 }
 
-func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *types.Header, cc *client.CeloClient, logger log.Logger, dbWriter db.RosettaDBWriter, cfg *Config) error {
+func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *types.Header, cc *client.CeloClient, baseLogger log.Logger, dbWriter db.RosettaDBWriter, cfg *Config) error {
 	r, err := registry.New(cc)
 	if err != nil {
 		return err
@@ -155,9 +155,10 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 			return ctx.Err()
 		case h = <-headers:
 		}
-		logHeader(logger, h)
+		blockProcessStartedAt := time.Now()
 
-		logger = logger.New("blockTimestamp", time.Unix(int64(h.Time), 0).Format(time.RFC3339), "blockNumber", h.Number.Int64(), "blockGasUsed", h.GasUsed)
+		logHeader(baseLogger, h)
+		logger := baseLogger.New("blockTimestamp", time.Unix(int64(h.Time), 0).Format(time.RFC3339), "blockNumber", h.Number.Int64(), "blockGasUsed", h.GasUsed)
 
 		finishHeader := func(ctx context.Context) error {
 			if err := dbWriter.ApplyChanges(ctx, h.Number); err != nil {

--- a/monitor/main.go
+++ b/monitor/main.go
@@ -140,14 +140,6 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 
 	celoTokens := celotokens.New(r)
 
-	supported, err := cc.Rpc.SupportedModules()
-	if err != nil {
-		return err
-	}
-	_, debugEnabled := supported["debug"]
-
-	sensitiveAccounts := getSensitiveAccounts(cfg.SensitiveAccountsFilePath)
-
 	var h *types.Header
 	for {
 		select {
@@ -166,6 +158,7 @@ func blockProcessor(ctx context.Context, startBlock *big.Int, headers <-chan *ty
 			}
 
 			metrics.LastBlockProcessed.Set(float64(h.Number.Int64()))
+			metrics.ProcessBlockDuration.Observe(float64(time.Since(blockProcessStartedAt)) / float64(time.Second))
 			return nil
 		}
 


### PR DESCRIPTION
After doing some profiling and digging I found the offending code:

```go
logger = logger.New("blockTimestamp", time.Unix(int64(h.Time), 0).Format(time.RFC3339), "blockNumber", h.Number.Int64(), "blockGasUsed", h.GasUsed)
```

This code is part of the main loop and it continuously extends the `logger`, but the way that works under the hood is that it keeps an array of fields to which it appends. So basically after N blocks, the logger has the `blockTimestamp`, `blockNumber` and `blockGasUsed` fields N times in the array but when actually logging the fields override each other and the most recent values are used, but the full array is scanned for each log. The memory for this array continuously grows and is copied around a lot.

I had an eksportisto running from the start of the chain when I experimented with the performance improvement. I've also added a histogram of block processing times initially so I can visualise the slow down better. The effects of the fix are pretty clear.

<img width="580" alt="image" src="https://user-images.githubusercontent.com/304771/128317849-73c57b6a-f666-4195-9ecd-9af5493f741e.png">
<img width="571" alt="image" src="https://user-images.githubusercontent.com/304771/128317888-23efef99-21be-4da5-91f9-54bac1db4959.png">


