### PR TITLE
eksportisto 2.0 fixes

### DIFF
--- a/indexer/handler.go
+++ b/indexer/handler.go
@@ -103,6 +103,7 @@ func (handler *blockHandler) loadBlock(ctx context.Context) error {
 	handler.transactions = handler.block.Transactions()
 
 	handler.blockRow = NewRow(
+		"indexerTimestamp", time.Now().UTC().Format(time.RFC3339),
 		"blockTimestamp", time.Unix(int64(handler.block.Time()), 0).Format(time.RFC3339),
 		"blockNumber", handler.block.NumberU64(),
 		"blockGasUsed", handler.block.GasUsed(),

--- a/indexer/helpers.go
+++ b/indexer/helpers.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -83,9 +84,9 @@ func (handler *blockHandler) extractEvent(
 	// extract raw event log
 	rawEvent, err := json.Marshal(eventLog)
 	if err != nil {
-		rows <- eventRow.Extend("rawEventErr", err)
+		eventRow = eventRow.Extend("rawEventErr", err)
 	} else if rawEvent != nil {
-		rows <- eventRow.Extend("rawEvent", string(rawEvent))
+		eventRow = eventRow.Extend("rawEvent", string(rawEvent))
 	}
 
 	parsed, err := handler.registry.TryParseLog(ctx, *eventLog, handler.blockNumber)
@@ -107,7 +108,6 @@ func (handler *blockHandler) extractEvent(
 				"contract", parsed.Contract,
 				"event", parsed.Event,
 				"loggedBy", eventLog.Address.Hex(),
-				"rawEventErr", err,
 			).Extend(logSlice...)
 		}
 	} else {
@@ -125,7 +125,7 @@ func (handler *blockHandler) extractEvent(
 			"topic1", getTopic(1),
 			"topic2", getTopic(2),
 			"topic3", getTopic(3),
-			"data", eventLog.Data,
+			"data", hex.EncodeToString(eventLog.Data),
 		)
 	}
 	return nil

--- a/indexer/helpers.go
+++ b/indexer/helpers.go
@@ -84,14 +84,13 @@ func (handler *blockHandler) extractEvent(
 	rawEvent, err := json.Marshal(eventLog)
 	if err != nil {
 		rows <- eventRow.Extend("rawEventErr", err)
-	} else {
+	} else if rawEvent != nil {
 		rows <- eventRow.Extend("rawEvent", string(rawEvent))
 	}
 
 	parsed, err := handler.registry.TryParseLog(ctx, *eventLog, handler.blockNumber)
 	if err != nil {
 		logger.Error("log parsing failed", "err", err)
-
 	} else if parsed != nil {
 		// If the contract with the event has an event handler, call it with the parsed event
 		if handler.isTip() {

--- a/indexer/helpers.go
+++ b/indexer/helpers.go
@@ -1,17 +1,18 @@
 package indexer
 
 import (
-	"context"
-	"encoding/hex"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
+    "context"
+    "encoding/hex"
+    "encoding/json"
+    "fmt"
+    "io/ioutil"
+    "strings"
 
-	"github.com/celo-org/celo-blockchain/common"
-	"github.com/celo-org/celo-blockchain/core/types"
-	"github.com/celo-org/kliento/contracts/helpers"
-	"github.com/celo-org/kliento/registry"
-	"github.com/spf13/viper"
+    "github.com/celo-org/celo-blockchain/common"
+    "github.com/celo-org/celo-blockchain/core/types"
+    "github.com/celo-org/kliento/contracts/helpers"
+    "github.com/celo-org/kliento/registry"
+    "github.com/spf13/viper"
 )
 
 var EpochSize = uint64(17280)   // 17280 = 12 * 60 * 24
@@ -20,113 +21,112 @@ var BlocksPerHour = uint64(720) // 720 = 12 * 60
 type Mode string
 
 const (
-	DataMode    Mode = "data"
-	MetricsMode Mode = "metrics"
-	BothMode    Mode = "both"
+    DataMode    Mode = "data"
+    MetricsMode Mode = "metrics"
+    BothMode    Mode = "both"
 )
 
 func newMode(mode string) (Mode, error) {
-	if mode == string(DataMode) {
-		return DataMode, nil
-	} else if mode == string(MetricsMode) {
-		return MetricsMode, nil
-	} else if mode == string(BothMode) {
-		return BothMode, nil
-	} else {
-		return "", fmt.Errorf("invalid mode %s", mode)
-	}
+    if mode == string(DataMode) {
+        return DataMode, nil
+    } else if mode == string(MetricsMode) {
+        return MetricsMode, nil
+    } else if mode == string(BothMode) {
+        return BothMode, nil
+    } else {
+        return "", fmt.Errorf("invalid mode %s", mode)
+    }
 }
 
 func (mode Mode) shouldCollectData() bool {
-	return mode == DataMode || mode == BothMode
+    return mode == DataMode || mode == BothMode
 }
 
 func (mode Mode) shouldCollectMetrics() bool {
-	return mode == MetricsMode || mode == BothMode
+    return mode == MetricsMode || mode == BothMode
 }
 
 func loadSensitiveAccounts() map[common.Address]string {
-	filePath := viper.GetString("indexer.sensitiveAccountsPath")
-	if filePath == "" {
-		return make(map[common.Address]string)
-	}
+    filePath := viper.GetString("indexer.sensitiveAccountsPath")
+    if filePath == "" {
+        return make(map[common.Address]string)
+    }
 
-	bz, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		panic(err)
-	}
+    bz, err := ioutil.ReadFile(filePath)
+    if err != nil {
+        panic(err)
+    }
 
-	var addresses map[common.Address]string
-	err = json.Unmarshal(bz, &addresses)
-	if err != nil {
-		panic(err)
-	}
+    var addresses map[common.Address]string
+    err = json.Unmarshal(bz, &addresses)
+    if err != nil {
+        panic(err)
+    }
 
-	return addresses
+    return addresses
 }
 
 // extractEvent parses an event log and decodes when possible,
 // it outputs rows. It is defined on the blockHandler because
 // it's shared between multiple processors.
 func (handler *blockHandler) extractEvent(
-	ctx context.Context,
-	txHash common.Hash,
-	eventIdx int,
-	eventLog *types.Log,
-	txRow *Row,
-	rows chan *Row,
+    ctx context.Context,
+    txHash common.Hash,
+    eventIdx int,
+    eventLog *types.Log,
+    txRow *Row,
+    rows chan *Row,
 ) error {
-	logger := handler.logger.New("txHash", txHash.String(), "logTxIndex", eventIdx, "logBlockIndex", eventLog.Index)
-	eventRow := txRow.Extend("logTxIndex", eventIdx, "logBlockIndex", eventLog.Index).WithId(
-		fmt.Sprintf("%s.event.%d", txHash.String(), eventIdx),
-	)
+    logger := handler.logger.New("txHash", txHash.String(), "logTxIndex", eventIdx, "logBlockIndex", eventLog.Index)
+    eventRowId := fmt.Sprintf("%s.event.%d", txHash.String(), eventIdx)
+    eventRow := txRow.Extend("logTxIndex", eventIdx, "logBlockIndex", eventLog.Index).WithId(eventRowId)
 
-	// extract raw event log
-	rawEvent, err := json.Marshal(eventLog)
-	if err != nil {
-		eventRow = eventRow.Extend("rawEventErr", err)
-	} else if rawEvent != nil {
-		eventRow = eventRow.Extend("rawEvent", string(rawEvent))
-	}
+    rawEvent, err := json.Marshal(eventLog)
+    if err != nil {
+        logger.Error("event log marshalling failed", "err", err)
+    } else if rawEvent != nil {
+        getTopic := func(index int) interface{} {
+            if len(eventLog.Topics) > index {
+                return eventLog.Topics[index]
+            } else {
+                return nil
+            }
+        }
+        addHexPrefix := func(eventLogData string) interface{} {
+            var sb strings.Builder
+            sb.WriteString("0x")
+            sb.WriteString(eventLogData)
+            return sb.String()
+        }
+        eventRow = eventRow.Extend("type", "Event",
+            "loggedBy", eventLog.Address.Hex(),
+            "rawEvent", string(rawEvent),
+            "topic0", getTopic(0),
+            "topic1", getTopic(1),
+            "topic2", getTopic(2),
+            "topic3", getTopic(3),
+            "data",  addHexPrefix(hex.EncodeToString(eventLog.Data))).WithId(eventRowId)
+    }
 
-	parsed, err := handler.registry.TryParseLog(ctx, *eventLog, handler.blockNumber)
-	if err != nil {
-		logger.Error("log parsing failed", "err", err)
-	} else if parsed != nil {
-		// If the contract with the event has an event handler, call it with the parsed event
-		if handler.isTip() {
-			if handler, ok := handler.eventHandlers[registry.ContractID(parsed.Contract)]; ok {
-				handler.HandleEvent(parsed)
-			}
-		}
-		logSlice, err := helpers.EventToSlice(parsed.Log)
-		if err != nil {
-			logger.Error("event slice encoding failed", "contract", parsed.Contract, "event", parsed.Event, "err", err)
-		} else {
-			rows <- eventRow.Extend(
-				"type", "Event",
-				"contract", parsed.Contract,
-				"event", parsed.Event,
-				"loggedBy", eventLog.Address.Hex(),
-			).Extend(logSlice...)
-		}
-	} else {
-		getTopic := func(index int) interface{} {
-			if len(eventLog.Topics) > index {
-				return eventLog.Topics[index]
-			} else {
-				return nil
-			}
-		}
-		rows <- eventRow.Extend(
-			"loggedBy", eventLog.Address.Hex(),
-			"type", "Event",
-			"topic0", getTopic(0),
-			"topic1", getTopic(1),
-			"topic2", getTopic(2),
-			"topic3", getTopic(3),
-			"data", hex.EncodeToString(eventLog.Data),
-		)
-	}
-	return nil
+    parsed, err := handler.registry.TryParseLog(ctx, *eventLog, handler.blockNumber)
+    if err != nil {
+        logger.Error("log parsing failed", "err", err)
+    } else if parsed != nil {
+        // If the contract with the event has an event handler, call it with the parsed event
+        if handler.isTip() {
+            if handler, ok := handler.eventHandlers[registry.ContractID(parsed.Contract)]; ok {
+                handler.HandleEvent(parsed)
+            }
+        }
+        logSlice, err := helpers.EventToSlice(parsed.Log)
+        if err != nil {
+            logger.Error("event slice encoding failed", "contract", parsed.Contract, "event", parsed.Event, "err", err)
+        } else {
+            rows <- eventRow.Extend(
+                "contract", parsed.Contract,
+                "event", parsed.Event,
+            ).Extend(logSlice...).WithId(eventRowId)
+        }
+    }
+    return nil
 }

--- a/indexer/helpers.go
+++ b/indexer/helpers.go
@@ -1,18 +1,18 @@
 package indexer
 
 import (
-    "context"
-    "encoding/hex"
-    "encoding/json"
-    "fmt"
-    "io/ioutil"
-    "strings"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
 
-    "github.com/celo-org/celo-blockchain/common"
-    "github.com/celo-org/celo-blockchain/core/types"
-    "github.com/celo-org/kliento/contracts/helpers"
-    "github.com/celo-org/kliento/registry"
-    "github.com/spf13/viper"
+	"github.com/celo-org/celo-blockchain/common"
+	"github.com/celo-org/celo-blockchain/core/types"
+	"github.com/celo-org/kliento/contracts/helpers"
+	"github.com/celo-org/kliento/registry"
+	"github.com/spf13/viper"
 )
 
 var EpochSize = uint64(17280)   // 17280 = 12 * 60 * 24
@@ -21,112 +21,112 @@ var BlocksPerHour = uint64(720) // 720 = 12 * 60
 type Mode string
 
 const (
-    DataMode    Mode = "data"
-    MetricsMode Mode = "metrics"
-    BothMode    Mode = "both"
+	DataMode    Mode = "data"
+	MetricsMode Mode = "metrics"
+	BothMode    Mode = "both"
 )
 
 func newMode(mode string) (Mode, error) {
-    if mode == string(DataMode) {
-        return DataMode, nil
-    } else if mode == string(MetricsMode) {
-        return MetricsMode, nil
-    } else if mode == string(BothMode) {
-        return BothMode, nil
-    } else {
-        return "", fmt.Errorf("invalid mode %s", mode)
-    }
+	if mode == string(DataMode) {
+		return DataMode, nil
+	} else if mode == string(MetricsMode) {
+		return MetricsMode, nil
+	} else if mode == string(BothMode) {
+		return BothMode, nil
+	} else {
+		return "", fmt.Errorf("invalid mode %s", mode)
+	}
 }
 
 func (mode Mode) shouldCollectData() bool {
-    return mode == DataMode || mode == BothMode
+	return mode == DataMode || mode == BothMode
 }
 
 func (mode Mode) shouldCollectMetrics() bool {
-    return mode == MetricsMode || mode == BothMode
+	return mode == MetricsMode || mode == BothMode
 }
 
 func loadSensitiveAccounts() map[common.Address]string {
-    filePath := viper.GetString("indexer.sensitiveAccountsPath")
-    if filePath == "" {
-        return make(map[common.Address]string)
-    }
+	filePath := viper.GetString("indexer.sensitiveAccountsPath")
+	if filePath == "" {
+		return make(map[common.Address]string)
+	}
 
-    bz, err := ioutil.ReadFile(filePath)
-    if err != nil {
-        panic(err)
-    }
+	bz, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		panic(err)
+	}
 
-    var addresses map[common.Address]string
-    err = json.Unmarshal(bz, &addresses)
-    if err != nil {
-        panic(err)
-    }
+	var addresses map[common.Address]string
+	err = json.Unmarshal(bz, &addresses)
+	if err != nil {
+		panic(err)
+	}
 
-    return addresses
+	return addresses
 }
 
 // extractEvent parses an event log and decodes when possible,
 // it outputs rows. It is defined on the blockHandler because
 // it's shared between multiple processors.
 func (handler *blockHandler) extractEvent(
-    ctx context.Context,
-    txHash common.Hash,
-    eventIdx int,
-    eventLog *types.Log,
-    txRow *Row,
-    rows chan *Row,
+	ctx context.Context,
+	txHash common.Hash,
+	eventIdx int,
+	eventLog *types.Log,
+	txRow *Row,
+	rows chan *Row,
 ) error {
-    logger := handler.logger.New("txHash", txHash.String(), "logTxIndex", eventIdx, "logBlockIndex", eventLog.Index)
-    eventRowId := fmt.Sprintf("%s.event.%d", txHash.String(), eventIdx)
-    eventRow := txRow.Extend("logTxIndex", eventIdx, "logBlockIndex", eventLog.Index).WithId(eventRowId)
+	logger := handler.logger.New("txHash", txHash.String(), "logTxIndex", eventIdx, "logBlockIndex", eventLog.Index)
+	eventRowId := fmt.Sprintf("%s.event.%d", txHash.String(), eventIdx)
+	eventRow := txRow.Extend("logTxIndex", eventIdx, "logBlockIndex", eventLog.Index).WithId(eventRowId)
 
-    rawEvent, err := json.Marshal(eventLog)
-    if err != nil {
-        logger.Error("event log marshalling failed", "err", err)
-    } else if rawEvent != nil {
-        getTopic := func(index int) interface{} {
-            if len(eventLog.Topics) > index {
-                return eventLog.Topics[index]
-            } else {
-                return nil
-            }
-        }
-        addHexPrefix := func(eventLogData string) interface{} {
-            var sb strings.Builder
-            sb.WriteString("0x")
-            sb.WriteString(eventLogData)
-            return sb.String()
-        }
-        eventRow = eventRow.Extend("type", "Event",
-            "loggedBy", eventLog.Address.Hex(),
-            "rawEvent", string(rawEvent),
-            "topic0", getTopic(0),
-            "topic1", getTopic(1),
-            "topic2", getTopic(2),
-            "topic3", getTopic(3),
-            "data",  addHexPrefix(hex.EncodeToString(eventLog.Data))).WithId(eventRowId)
-    }
+	rawEvent, err := json.Marshal(eventLog)
+	if err != nil {
+		logger.Error("event log marshalling failed", "err", err)
+	} else if rawEvent != nil {
+		getTopic := func(index int) interface{} {
+			if len(eventLog.Topics) > index {
+				return eventLog.Topics[index]
+			} else {
+				return nil
+			}
+		}
+		addHexPrefix := func(eventLogData string) interface{} {
+			var sb strings.Builder
+			sb.WriteString("0x")
+			sb.WriteString(eventLogData)
+			return sb.String()
+		}
+		eventRow = eventRow.Extend("type", "Event",
+			"loggedBy", eventLog.Address.Hex(),
+			"rawEvent", string(rawEvent),
+			"topic0", getTopic(0),
+			"topic1", getTopic(1),
+			"topic2", getTopic(2),
+			"topic3", getTopic(3),
+			"data", addHexPrefix(hex.EncodeToString(eventLog.Data))).WithId(eventRowId)
+	}
 
-    parsed, err := handler.registry.TryParseLog(ctx, *eventLog, handler.blockNumber)
-    if err != nil {
-        logger.Error("log parsing failed", "err", err)
-    } else if parsed != nil {
-        // If the contract with the event has an event handler, call it with the parsed event
-        if handler.isTip() {
-            if handler, ok := handler.eventHandlers[registry.ContractID(parsed.Contract)]; ok {
-                handler.HandleEvent(parsed)
-            }
-        }
-        logSlice, err := helpers.EventToSlice(parsed.Log)
-        if err != nil {
-            logger.Error("event slice encoding failed", "contract", parsed.Contract, "event", parsed.Event, "err", err)
-        } else {
-            rows <- eventRow.Extend(
-                "contract", parsed.Contract,
-                "event", parsed.Event,
-            ).Extend(logSlice...).WithId(eventRowId)
-        }
-    }
-    return nil
+	parsed, err := handler.registry.TryParseLog(ctx, *eventLog, handler.blockNumber)
+	if err != nil {
+		logger.Error("log parsing failed", "err", err)
+	} else if parsed != nil {
+		// If the contract with the event has an event handler, call it with the parsed event
+		if handler.isTip() {
+			if handler, ok := handler.eventHandlers[registry.ContractID(parsed.Contract)]; ok {
+				handler.HandleEvent(parsed)
+			}
+		}
+		logSlice, err := helpers.EventToSlice(parsed.Log)
+		if err != nil {
+			logger.Error("event slice encoding failed", "contract", parsed.Contract, "event", parsed.Event, "err", err)
+		} else {
+			rows <- eventRow.Extend(
+				"contract", parsed.Contract,
+				"event", parsed.Event,
+			).Extend(logSlice...).WithId(eventRowId)
+		}
+	}
+	return nil
 }

--- a/indexer/proc_epochRewards.go
+++ b/indexer/proc_epochRewards.go
@@ -129,7 +129,7 @@ func (proc epochRewardsProcessor) CollectData(ctx context.Context, rows chan *Ro
 	}
 
 	rows <- contractRow.ViewCall(
-		"geVotingGoldFraction",
+		"getVotingGoldFraction",
 		"votingGoldFraction", helpers.FromFixed(votingGoldFraction),
 	)
 

--- a/legacy/monitor/epochRewards.go
+++ b/legacy/monitor/epochRewards.go
@@ -95,7 +95,7 @@ func (p epochRewardsProcessor) ObserveState(opts *bind.CallOpts) error {
 
 	logStateViewCall(
 		logger,
-		"method", "geVotingGoldFraction",
+		"method", "getVotingGoldFraction",
 		"votingGoldFraction", helpers.FromFixed(votingGoldFraction),
 	)
 

--- a/schema.json
+++ b/schema.json
@@ -465,7 +465,7 @@
         "mode": "NULLABLE"
     },
     {
-        "name": "intererval",
+        "name": "interval",
         "type": "FLOAT",
         "mode": "NULLABLE"
     },

--- a/schema.json
+++ b/schema.json
@@ -21,7 +21,7 @@
     },
     {
         "name": "blockTimestamp",
-        "type": "STRING",
+        "type": "TIMESTAMP",
         "mode": "NULLABLE"
     },
     {

--- a/schema.json
+++ b/schema.json
@@ -753,5 +753,15 @@
         "name": "weights",
         "type": "STRING",
         "mode": "NULLABLE"
+    },
+    {
+        "name": "transactionCount",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
+        "name": "deposit",
+        "type": "STRING",
+        "mode": "NULLABLE"
     }
 ]

--- a/schema.json
+++ b/schema.json
@@ -1,5 +1,10 @@
 [
     {
+        "name": "indexerTimestamp",
+        "type": "TIMESTAMP",
+        "mode": "NULLABLE"
+    },
+    {
         "name": "type",
         "type": "STRING",
         "mode": "NULLABLE"

--- a/schema.json
+++ b/schema.json
@@ -763,5 +763,20 @@
         "name": "deposit",
         "type": "STRING",
         "mode": "NULLABLE"
+    },
+    {
+        "name": "proposer",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
+        "name": "reporter",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
+        "name": "slashed",
+        "type": "STRING",
+        "mode": "NULLABLE"
     }
 ]

--- a/schema.json
+++ b/schema.json
@@ -465,7 +465,7 @@
         "mode": "NULLABLE"
     },
     {
-        "name": "INTEGERerval",
+        "name": "intererval",
         "type": "FLOAT",
         "mode": "NULLABLE"
     },

--- a/schema.json
+++ b/schema.json
@@ -20,18 +20,8 @@
         "mode": "NULLABLE"
     },
     {
-        "name": "timestamp",
-        "type": "STRING",
-        "mode": "NULLABLE"
-    },
-    {
         "name": "blockTimestamp",
         "type": "TIMESTAMP",
-        "mode": "NULLABLE"
-    },
-    {
-        "name": "msg",
-        "type": "STRING",
         "mode": "NULLABLE"
     },
     {
@@ -581,11 +571,6 @@
     },
     {
         "name": "amount",
-        "type": "STRING",
-        "mode": "NULLABLE"
-    },
-    {
-        "name": "err",
         "type": "STRING",
         "mode": "NULLABLE"
     },

--- a/schema.json
+++ b/schema.json
@@ -30,11 +30,6 @@
         "mode": "NULLABLE"
     },
     {
-        "name": "rawEventErr",
-        "type": "STRING",
-        "mode": "NULLABLE"
-    },
-    {
         "name": "blockGasUsed",
         "type": "INTEGER",
         "mode": "NULLABLE"

--- a/schema.json
+++ b/schema.json
@@ -125,11 +125,6 @@
         "mode": "NULLABLE"
     },
     {
-        "name": "rawEvent",
-        "type": "STRING",
-        "mode": "NULLABLE"
-    },
-    {
         "name": "loggedBy",
         "type": "STRING",
         "mode": "NULLABLE"

--- a/schema.json
+++ b/schema.json
@@ -25,6 +25,16 @@
         "mode": "NULLABLE"
     },
     {
+        "name": "rawEvent",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
+        "name": "rawEventErr",
+        "type": "STRING",
+        "mode": "NULLABLE"
+    },
+    {
         "name": "blockGasUsed",
         "type": "INTEGER",
         "mode": "NULLABLE"
@@ -257,6 +267,11 @@
     {
         "name": "index",
         "type": "INTEGER",
+        "mode": "NULLABLE"
+    },
+    {
+        "name": "timestamp",
+        "type": "STRING",
         "mode": "NULLABLE"
     },
     {

--- a/schema.json
+++ b/schema.json
@@ -31,7 +31,7 @@
     },
     {
         "name": "blockGasUsed",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -56,7 +56,7 @@
     },
     {
         "name": "txIndex",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -66,7 +66,7 @@
     },
     {
         "name": "gasUsed",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -81,12 +81,12 @@
     },
     {
         "name": "logTxIndex",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
         "name": "logBlockIndex",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -116,7 +116,7 @@
     },
     {
         "name": "attestationsRequested",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -196,7 +196,7 @@
     },
     {
         "name": "minAttestations",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -266,7 +266,7 @@
     },
     {
         "name": "index",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -281,7 +281,7 @@
     },
     {
         "name": "numRates",
-        "type": "INT",
+        "type": "INTEGER",
         "mode": "NULLABLE"
     },
     {
@@ -470,7 +470,7 @@
         "mode": "NULLABLE"
     },
     {
-        "name": "interval",
+        "name": "INTEGERerval",
         "type": "FLOAT",
         "mode": "NULLABLE"
     },


### PR DESCRIPTION
This PR adds and fixes some smaller stuff to eksportisto 2.0:
- Adds new necessary schema fields, optimizes BigQuery datatypes, removes unused fields
- Exporting an `indexerTimestamp`
- Exporting raw event logs and raw event log errors
- Always exports raw log event information, not just when parsing fails
- Fixes decoding of `eventLog.Data` from `[]uint8` bytes array to correct `hex string` (previously automatic decoding in BigQuery to `base64 string`)
- Fixes function name from `geVotingGoldFraction` to `getVotingGoldFraction`
- Fixes some row id logic: Before it was assigned when creating but lost when extending a row