### PR TITLE
Catch errors from EnableCaching

### DIFF
--- a/indexer/handler.go
+++ b/indexer/handler.go
@@ -54,7 +54,10 @@ func (w *worker) newBlockHandler(block uint64) (*blockHandler, error) {
 // run starts the processing of a block by firing all processors
 // and a routine to collect rows from a channel
 func (handler *blockHandler) run(ctx context.Context) (err error) {
-	handler.registry.EnableCaching(ctx, handler.blockNumber)
+	err = handler.registry.EnableCaching(ctx, handler.blockNumber)
+	if err != nil {
+		return err
+	}
 	group, ctx := errgroup.WithContext(ctx)
 	rowsChan := make(chan *Row, 1000)
 


### PR DESCRIPTION
It's *possible* this is the culprit behind https://app.zenhub.com/workspaces/platform-economics---sprint-board-5f89a1e34ce1b6001230771d/issues/celo-org/eksportisto/75.

In eksportisto log parsing logic, [this](https://github.com/celo-org/eksportisto/blob/bowd/Eksportisto-2.0/indexer/helpers.go#L104) `else` block was being executed when we didn't want it to. This would happen if `err == nil && parsed == nil` following the TryParseLog call. One possible way for this to happen is if [this line](https://github.com/celo-org/kliento/blob/master/registry/registry.go#L168) does not evaluate to true. This could happen if the cache is not properly populated, causing `id` to be `""`.

Unfortunately there's no good way to test if this really was the culprit, but I poked around the code quite a bit and this is the only thing I can spot.