### PR TITLE
Make chainTip publisher queue configurable.

### DIFF
--- a/cmd/publisher.go
+++ b/cmd/publisher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 
+	"github.com/celo-org/eksportisto/indexer"
 	"github.com/celo-org/eksportisto/metrics"
 	"github.com/celo-org/eksportisto/publisher"
 	"github.com/celo-org/kliento/utils/service"
@@ -37,4 +38,5 @@ also ensure that blocks are retried when errors occur.`,
 
 func init() {
 	viper.SetDefault("publisher.backfill", false)
+	viper.SetDefault("publisher.chainTip.queue", indexer.Tip)
 }

--- a/indexer/input.go
+++ b/indexer/input.go
@@ -11,7 +11,7 @@ const (
 	Backfill = "backfill"
 )
 
-func parseInput(input string) (rdb.Queue, error) {
+func ParseInput(input string) (rdb.Queue, error) {
 	if input == Tip {
 		return rdb.TipQueue, nil
 	} else if input == Backfill {

--- a/indexer/worker.go
+++ b/indexer/worker.go
@@ -60,7 +60,7 @@ func NewWorker(ctx context.Context) (*Worker, error) {
 		return nil, fmt.Errorf("indexer.destination invalid, expecting: stdout, bigquery")
 	}
 
-	input, err := parseInput(viper.GetString("indexer.source"))
+	input, err := ParseInput(viper.GetString("indexer.source"))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The chainTip publisher can now be configured to publish to either the
"backfill" or the "tip" queues.