### PR TITLE
Set the backfill cursor metric on start-up.

### DIFF
--- a/publisher/backfill.go
+++ b/publisher/backfill.go
@@ -41,6 +41,7 @@ func newBackfillPublisher(ctx context.Context) (publisher, error) {
 	} else if err != nil {
 		return nil, err
 	}
+	metrics.BackfillCursor.Set(float64(cursor))
 
 	handler := log.LvlFilterHandler(log.LvlInfo, log.StreamHandler(os.Stdout, log.JSONFormat()))
 	logger := log.New()


### PR DESCRIPTION
The metric was only being set when it was updated, which can take a
long time for large batchSizes if the publisher is re-started.