### PR TITLE
Avoid running costly processor operations.

### DIFF
--- a/indexer/handler.go
+++ b/indexer/handler.go
@@ -135,7 +135,7 @@ func (handler *blockHandler) spawnProcessors(ctx context.Context, rowsChan chan 
 					)
 				})
 			}
-			if processor.ShouldCollect() {
+			if handler.collectData && processor.ShouldCollect() {
 				group.Go(func() error {
 					return metrics.RecordProcessorDuration(
 						func() error { return handler.checkError(processor.CollectData(ctx, rowsChan)) },

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -95,6 +95,7 @@ func Start(ctx context.Context) error {
 			if err != nil {
 				logger.Error("Failed to process block.", "number", blockNumber, "err", err)
 			} else {
+				logger.Info("Finished processing block.", "number", blockNumber, "processing_time", blockProcessingDuration)
 				metrics.LastBlockProcessed.WithLabelValues("monitor").Set(float64(blockNumber))
 			}
 		}


### PR DESCRIPTION
Do not call the BigQuery row generating CollectData methods if
eksportisto is running in monitoring mode.