### PR TITLE
Add transaction tracing timeout option

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,7 @@ func init() {
 	rootCmd.PersistentFlags().Int("monitoring-port", 8080, "Port for the prometheus server")
 	rootCmd.PersistentFlags().String("celo-node-uri", "", "URI for the Celo Blockchain Node")
 	rootCmd.PersistentFlags().Bool("profiling", false, "Enable pprof on the http server")
-	rootCmd.PersistentFlags().Duration("traceTransactionTimeout", time.Second*50, "The timeout to pass to the blockchain node when tracing, prviously hardocded to 50s so defaults to 50s, 120s is a recommended value to be able to trace all transactions as of Jan 2022")
+	rootCmd.PersistentFlags().Duration("traceTransactionTimeout", time.Second*120, "The timeout that eksportisto passes to the blockchain node when tracing transactions. The default of 120s is recommended to be able to trace all transactions as of Jan 2022")
 
 	rootCmd.AddCommand(publisherCmd)
 	rootCmd.AddCommand(indexerCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.PersistentFlags().Int("monitoring-port", 8080, "Port for the prometheus server")
 	rootCmd.PersistentFlags().String("celo-node-uri", "", "URI for the Celo Blockchain Node")
 	rootCmd.PersistentFlags().Bool("profiling", false, "Enable pprof on the http server")
+	rootCmd.PersistentFlags().Duration("traceTransactionTimeout", time.Second*50, "The timeout to pass to the blockchain node when tracing, prviously hardocded to 50s so defaults to 50s, 120s is a recommended value to be able to trace all transactions as of Jan 2022")
 
 	rootCmd.AddCommand(publisherCmd)
 	rootCmd.AddCommand(indexerCmd)
@@ -44,10 +46,12 @@ func initConfig() {
 	viper.SetDefault("monitoring.port", 8080)
 	viper.SetDefault("monitoring.address", "127.0.0.1")
 	viper.SetDefault("monitoring.requestTimeoutSeconds", 24)
+	viper.SetDefault("traceTransactionTimeout", time.Second*50)
 	viper.BindPFlag("monitoring.port", rootCmd.Flags().Lookup("monitoring-port"))
 	viper.BindPFlag("indexer.mode", indexerCmd.Flags().Lookup("indexer-mode"))
 	viper.BindPFlag("celoNodeURI", rootCmd.Flags().Lookup("celo-node-uri"))
 	viper.BindPFlag("profiling", rootCmd.Flags().Lookup("profiling"))
+	viper.BindPFlag("traceTransactionTimeout", rootCmd.Flags().Lookup("traceTransactionTimeout"))
 
 	if cfgFile != "" {
 		// Use config file from the flag.

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,3 +1,11 @@
+# Determines the timeout used when making debug_TraceTransaction calls to the
+# blockchain node. 
+#
+# The timeout was previously hardcoded to 50s in kliento but was too small to
+# trace all transactions.  A value of 120s should safely trace all transactions
+# that we have seen so far (Jan 2022).
+traceTransactionTimeout: "120s"
+
 monitoring:
   port: 8080
   address: localhost

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/bigquery v1.8.0
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/celo-org/celo-blockchain v1.3.2
-	github.com/celo-org/kliento v0.2.1-0.20211201165252-37af78cb0d3f
+	github.com/celo-org/kliento v0.2.1-0.20220118184311-83bd0da5cb6c
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/celo-org/kliento v0.2.1-0.20210512182137-971739185f65 h1:AcOSCTFxvymR
 github.com/celo-org/kliento v0.2.1-0.20210512182137-971739185f65/go.mod h1:6aoUqGKc/g1blbbJeYi/ZXnbyrk5Yujyt5QTcukeTs4=
 github.com/celo-org/kliento v0.2.1-0.20211201165252-37af78cb0d3f h1:sbj56IwdCAwP2jtit7nVeJn3yUkPBd/noHPW3LnQpVs=
 github.com/celo-org/kliento v0.2.1-0.20211201165252-37af78cb0d3f/go.mod h1:6aoUqGKc/g1blbbJeYi/ZXnbyrk5Yujyt5QTcukeTs4=
+github.com/celo-org/kliento v0.2.1-0.20220118184311-83bd0da5cb6c h1:AT/P4o61ttp88T4dOYAr9XsyEWHYvEVtixWg1XpYjOo=
+github.com/celo-org/kliento v0.2.1-0.20220118184311-83bd0da5cb6c/go.mod h1:6aoUqGKc/g1blbbJeYi/ZXnbyrk5Yujyt5QTcukeTs4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/cp v0.1.0 h1:SE+dxFebS7Iik5LK0tsi1k9ZCxEaFX4AjQmoyA+1dJk=
 github.com/cespare/cp v0.1.0/go.mod h1:SOGHArjBr4JWaSDEVpWpo/hNg6RoKrls6Oh40hiwW+s=

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ traceTransactionTimeout: "120s"
 monitoring:
   port: 8080
   address: localhost
-  # Controls timeout for requests made to the exportisto service
+  # Controls timeout for requests made to the eksportisto service
   requestTimeoutSeconds: 25
 
 celoNodeURI: ws://localhost:8546

--- a/readme.md
+++ b/readme.md
@@ -35,9 +35,15 @@ The services use [spf13/viper](https://github.com/spf13/viper) and [spf13/cobra]
 ##### global
 
 ```yaml
+
+# Controls timeout for trace transaction requests made by eksportisto to the
+# blockchain node. 120s is a big enough timeout that it should support tracing
+# of all transactions seen so far (Jan 2022).
+traceTransactionTimeout: "120s"
 monitoring:
   port: 8080
   address: localhost
+  # Controls timeout for requests made to the exportisto service
   requestTimeoutSeconds: 25
 
 celoNodeURI: ws://localhost:8546


### PR DESCRIPTION
This option allows the timeout provided to blockchain nodes for
debug_TraceTransaction calls to be configured.

This update uses a new version of kliento that accepts the timeout
parameter.

Previously the timeout was hardcoded to 50s in kliento, but 50s was not
sufficient for larger transactions.

Going forward, to be safe I suggest 120s for the timeout.