### PR TITLE
adding trivy scanning to container builds for visibility

### DIFF
--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -1,0 +1,10 @@
+name: Docker Build Push
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  Build-Scan-Container:
+    uses: celo-org/reusable-workflows/.github/workflows/container-cicd-local.yaml@main
+    with:
+      dockerfile: Dockerfile

--- a/.github/workflows/docker-build-scan.yaml
+++ b/.github/workflows/docker-build-scan.yaml
@@ -1,8 +1,8 @@
 name: Docker Build Push
 on:
   pull_request:
+  push:
   workflow_dispatch:
-
 jobs:
   Build-Scan-Container:
     uses: celo-org/reusable-workflows/.github/workflows/container-cicd-local.yaml@main


### PR DESCRIPTION
Since we need more visibility into container security, adding a workflow that builds the container in github actions, scans it, and uploads that to the security tab.